### PR TITLE
More semantic ENV var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Set Up ###
 
 * Clone repo to local machine
-* Set USERNAME and PASSWORD environment variables to API user credentials for your Veracode account
+* Set `VERACODE_USERNAME` and `VERACODE_PASSWORD` environment variables to API user credentials for your Veracode account
 * Dependencies: json, activesupport, rest-client, and commander gems 
 * Add /path/to/clone/veracodecli/bin to system path
 * To run a scan use `veracodecli scan [app_name] [archivepath]`

--- a/apicore/API_functions.rb
+++ b/apicore/API_functions.rb
@@ -4,13 +4,13 @@ require 'rest-client'
 
 module VeracodeApiBase
 	def check_environment_login_variables
-		fail 'EnvironmentError: USERNAME or PASSWORD not set.' unless ENV['USERNAME'] != nil && ENV['PASSWORD'] != nil
+		fail 'EnvironmentError: VERACODE_USERNAME or VERACODE_PASSWORD not set.' unless ENV['VERACODE_USERNAME'] != nil && ENV['VERACODE_PASSWORD'] != nil
 	end
 
 	def veracode_api_request(api_call, api_version: '4.0', **params)
 		check_environment_login_variables
 		puts "Making call to #{api_call}"
-		response = RestClient.get "https://#{ENV['USERNAME']}:#{ENV['PASSWORD']}@analysiscenter.veracode.com/api/#{api_version}/#{api_call}", {params:params}
+		response = RestClient.get "https://#{ENV['VERACODE_USERNAME']}:#{ENV['VERACODE_PASSWORD']}@analysiscenter.veracode.com/api/#{api_version}/#{api_call}", {params:params}
 		response.body
 	end
 
@@ -47,10 +47,10 @@ module VeracodeApiScan
 	end
 
 	def submit_scan(hostname, archive_path)
-		app_id = validate_existance of: hostname, by: ENV['USERNAME']
+		app_id = validate_existance of: hostname, by: ENV['VERACODE_USERNAME']
 		#NOTE: curl must be used here because of a bug in the Veracode api. Ruby cannot be used while this bug is present.
 		#NOTE: preferred code: upload_result = veracode_api_request 'uploadfile.do', app_id: app_id, file: "#{archive_path}"
-		upload_result = `curl --url "https://#{ENV['USERNAME']}:#{ENV['PASSWORD']}@analysiscenter.veracode.com/api/4.0/uploadfile.do" -F 'app_id=#{app_id}' -F 'file=@#{archive_path}'`
+		upload_result = `curl --url "https://#{ENV['VERACODE_USERNAME']}:#{ENV['VERACODE_PASSWORD']}@analysiscenter.veracode.com/api/4.0/uploadfile.do" -F 'app_id=#{app_id}' -F 'file=@#{archive_path}'`
 		puts upload_result
 		#write upload_result, to_file: "#{app_id}_upload_result"
 		prescan_submission_result = veracode_api_request 'beginprescan.do', app_id: app_id, auto_scan: 'true'


### PR DESCRIPTION
Some systems might already USERNAME and PASSWORD ENV vars set. Any objection to prepending VERACODE_ to the ENV vars?